### PR TITLE
Add retry mechanism to pull_repo in case if fails with git.lock found

### DIFF
--- a/image/pull_server_ext.py
+++ b/image/pull_server_ext.py
@@ -47,9 +47,26 @@ def pull_repo(repo_url):
         shutil.rmtree(repo_path)
 
     app_log.info("Pulling %s", repo_url)
-    gp = GitPuller(repo_url, repo_dir, branch=branch_name)
-    for line in gp.pull():
-        app_log.info(line.rstrip("\n"))
+
+    import time
+
+    max_retries = 5
+    for attempt in range(max_retries):
+        try:
+            gp = GitPuller(repo_url, repo_dir, branch=branch_name)
+            for line in gp.pull():
+                app_log.info(line.rstrip("\n"))
+            break  # Success, exit the loop
+        except Exception as e:
+            if "Recent .git/index.lock found" in str(e):
+                app_log.warning(
+                    "Git lock found, waiting to retry... (%d/%d)",
+                    attempt + 1,
+                    max_retries,
+                )
+                time.sleep(2)
+            else:
+                raise e  # Raise any other unexpected errors
 
 
 def pull_everything():


### PR DESCRIPTION
Users have reported issues similar to what is displayed in the screenshot. Here is an attempt to fix that, by just waiting a few seconds and then retry

<img width="1996" height="1378" alt="Screenshot 2026-06-10 at 14 04 03" src="https://github.com/user-attachments/assets/106e07dd-def1-4005-bb8e-f56779760b7e" />
